### PR TITLE
ランキングのソートがAsc設定時もDescでソートされてしまう問題を修正

### DIFF
--- a/Assets/naichilab/GSSARanking/Scripts/RankingSceneManager.cs
+++ b/Assets/naichilab/GSSARanking/Scripts/RankingSceneManager.cs
@@ -130,7 +130,12 @@ namespace naichilab
 			var msg = Instantiate (readingNodePrefab, scrollViewContent);
 
 			var so = new SpreadSheetQuery ();
-			yield return so.OrderByDescending ("hiscore").Limit (30).FindAsync ();
+
+			if (RankingLoader.Instance.setting.Order == ScoreOrder.OrderByAscending) {
+				yield return so.OrderByAscending ("hiscore").Limit (30).FindAsync ();
+			} else {
+				yield return so.OrderByDescending ("hiscore").Limit (30).FindAsync ();
+			}
 
 			Debug.Log ("count : " + so.Count.ToString ());
 			Destroy (msg);


### PR DESCRIPTION
時間でランキングを付けた際に見つけたバグです。
常にDescソートしていた箇所を修正しました。
お手数おかけしますが、挙動やコード的に問題なければマージお願いします。