### PR TITLE
issue #11 ランキング登録の通信パケット改ざんの対策

### DIFF
--- a/Assets/naichilab/unity-simple-ranking/Sample/SampleSceneManager.cs
+++ b/Assets/naichilab/unity-simple-ranking/Sample/SampleSceneManager.cs
@@ -6,6 +6,12 @@ using UnityEngine.UI;
 
 public class SampleSceneManager : MonoBehaviour
 {
+    // メモリを書き換えてハイスコアを改ざんするハッキングが存在します。
+    // unity-simple-ranking 内で取り回しているスコアのメモリは書き換えを検知するようにしていますが、
+    // このクラスの score は検知していません。
+    // Webアプリであれば書き換えは難しい気がしますが、PC/iOS/Androidなどであれば、暗号化・もしくは書き換えを
+    // 検知する仕組みにすると安全です。
+
     public Text scoreText;
     [NonSerialized] int score = 0;
 

--- a/Assets/naichilab/unity-simple-ranking/Scripts/RankingLoader.cs
+++ b/Assets/naichilab/unity-simple-ranking/Scripts/RankingLoader.cs
@@ -17,6 +17,12 @@ namespace naichilab
         [SerializeField] public RankingBoards RankingBoards;
 
         /// <summary>
+        /// ハッシュ値による検証有効
+        /// ・検証無効であってもハッシュ値の計算・登録は行われます
+        /// </summary>
+        [SerializeField] public bool EnabledVerifyHash;
+
+        /// <summary>
         /// 表示対象のボード
         /// </summary>
         [NonSerialized] public RankingInfo CurrentRanking;

--- a/Assets/naichilab/unity-simple-ranking/Scripts/RankingRecord.cs
+++ b/Assets/naichilab/unity-simple-ranking/Scripts/RankingRecord.cs
@@ -1,0 +1,71 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+
+namespace naichilab
+{
+    /// <summary>
+    /// ランキングのレコード
+    /// ・主にハッシュ値を作成する目的で用意しました
+    /// </summary>
+    public class RankingRecord
+    {
+        public string ObjectID { get; private set; }
+        public string Name     { get; private set; }
+        public IScore Score    { get; private set; }
+        public string Hash     { get; private set; }
+
+        /// <summary>
+        /// コンストラクタ
+        /// ・DBから復元する場合はhashの引数があるものを使用します
+        /// </summary>
+        /// <param name="objectId"></param>
+        /// <param name="name"></param>
+        /// <param name="score"></param>
+        /// <param name="hash"></param>
+        public RankingRecord(string objectId, string name, IScore score)
+        {
+            ObjectID = objectId;
+            Name     = name;
+            Score    = score;
+            Hash     = CalcHash();
+        }
+        public RankingRecord(string objectId, string name, IScore score, string hash) 
+        {
+            ObjectID = objectId;
+            Name     = name;
+            Score    = score;
+            Hash     = hash;
+        }
+
+        /// <summary>
+        /// ハッシュ計算
+        /// ・計算が推測できないよう、通信パケットに含まれていないクライアントキーを混ぜ合わせています
+        /// </summary>
+        /// <returns></returns>
+        string CalcHash()
+        {
+            return (ObjectID + Name + Score.TextForSave + NCMB.NCMBSettings.ClientKey).ToHMACSHA256();
+        }
+
+        /// <summary>
+        /// ハッシュ値の検証
+        /// </summary>
+        /// <returns>true:OK、false:NG</returns>
+        public bool VerifyHash()
+        {
+            return CalcHash() == Hash;
+        }
+
+        /// <summary>
+        /// 名前変更
+        /// ・ハッシュ値が再計算されることに注意してください
+        /// </summary>
+        public void ChangeName(string name)
+        {
+            Name = name;
+            Hash = CalcHash();
+        }
+    }
+}

--- a/Assets/naichilab/unity-simple-ranking/Scripts/RankingRecord.cs
+++ b/Assets/naichilab/unity-simple-ranking/Scripts/RankingRecord.cs
@@ -11,8 +11,7 @@ namespace naichilab
     /// </summary>
     public class RankingRecord
     {
-        public string ObjectID { get; private set; }
-        public string Name     { get; private set; }
+        public string Name     { get; set; }
         public IScore Score    { get; private set; }
         public string Hash     { get; private set; }
 
@@ -20,20 +19,17 @@ namespace naichilab
         /// コンストラクタ
         /// ・DBから復元する場合はhashの引数があるものを使用します
         /// </summary>
-        /// <param name="objectId"></param>
         /// <param name="name"></param>
         /// <param name="score"></param>
         /// <param name="hash"></param>
-        public RankingRecord(string objectId, string name, IScore score)
+        public RankingRecord(string name, IScore score)
         {
-            ObjectID = objectId;
             Name     = name;
             Score    = score;
             Hash     = CalcHash();
         }
-        public RankingRecord(string objectId, string name, IScore score, string hash) 
+        public RankingRecord(string name, IScore score, string hash) 
         {
-            ObjectID = objectId;
             Name     = name;
             Score    = score;
             Hash     = hash;
@@ -46,7 +42,7 @@ namespace naichilab
         /// <returns></returns>
         string CalcHash()
         {
-            return (ObjectID + Name + Score.TextForSave + NCMB.NCMBSettings.ClientKey).ToHMACSHA256();
+            return (Name + Score.TextForSave + NCMB.NCMBSettings.ClientKey).ToHMACSHA256();
         }
 
         /// <summary>
@@ -59,12 +55,10 @@ namespace naichilab
         }
 
         /// <summary>
-        /// 名前変更
-        /// ・ハッシュ値が再計算されることに注意してください
+        /// ハッシュ再計算
         /// </summary>
-        public void ChangeName(string name)
+        public void RefreshHash()
         {
-            Name = name;
             Hash = CalcHash();
         }
     }

--- a/Assets/naichilab/unity-simple-ranking/Scripts/RankingRecord.cs.meta
+++ b/Assets/naichilab/unity-simple-ranking/Scripts/RankingRecord.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: b593a22851ee1ad4990386b87fd82762
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/naichilab/unity-simple-ranking/Scripts/RankingSceneManager.cs
+++ b/Assets/naichilab/unity-simple-ranking/Scripts/RankingSceneManager.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using NCMB;
 using NCMB.Extensions;
 
+
 namespace naichilab
 {
     public class RankingSceneManager : MonoBehaviour
@@ -12,7 +13,17 @@ namespace naichilab
         private const string OBJECT_ID = "objectId";
         private const string COLUMN_SCORE = "score";
         private const string COLUMN_NAME = "name";
+        private const string COLUMN_HASH = "hash";
 
+        // 表示するランキングデータの行数
+        private const int MAX_VIEW_ROW = 30;
+
+        // 読み込むランキングデータの行数
+        // ・ハッシュ値による検証有効時のみ使用します。
+        //   通信パケット改ざんが行われた場合、サーバ側ではじかない限りデータが登録されることは避けられません。
+        //   表示行数分だけ読み込むと、不正なデータがはじかれた結果、表示に必要なデータが足りなくなってしまいます。
+        //   仕方なく読み込み行数を増やしておくことで対応しておきます。
+        private const int MAX_READ_ROW = 60;
 
         [SerializeField] Text captionLabel;
         [SerializeField] Text scoreLabel;
@@ -45,9 +56,14 @@ namespace naichilab
         }
 
         private RankingInfo _board;
-        private IScore _lastScore;
+        private RankingRecord _lastScoreRecord; // メモリ書き換えを警戒してハッシュ値を含むレコードで保持しています
 
         private NCMBObject _ncmbRecord;
+
+        private bool EnabledVerifyHash
+        {
+            get { return RankingLoader.Instance.EnabledVerifyHash; }
+        }
 
         /// <summary>
         /// 入力した名前
@@ -70,7 +86,7 @@ namespace naichilab
         {
             sendScoreButton.interactable = false;
             _board = RankingLoader.Instance.CurrentRanking;
-            _lastScore = RankingLoader.Instance.LastScore;
+            _lastScoreRecord = new RankingRecord(ObjectID, "default", RankingLoader.Instance.LastScore); // 後で書き換えるので名前は適当に登録しています
 
             Debug.Log(BoardIdPlayerPrefsKey + "=" + PlayerPrefs.GetString(BoardIdPlayerPrefsKey, null));
 
@@ -79,10 +95,11 @@ namespace naichilab
 
         IEnumerator GetHighScoreAndRankingBoard()
         {
-            scoreLabel.text = _lastScore.TextForDisplay;
+            scoreLabel.text = _lastScoreRecord.Score.TextForDisplay;
             captionLabel.text = string.Format("{0}ランキング", _board.BoardName);
 
             //ハイスコア取得
+            RankingRecord hiScoreRecord = null;
             {
                 highScoreLabel.text = "取得中...";
 
@@ -96,8 +113,17 @@ namespace naichilab
                     _ncmbRecord = hiScoreCheck.Result.First();
 
                     var s = _board.BuildScore(_ncmbRecord[COLUMN_SCORE].ToString());
-                    highScoreLabel.text = s != null ? s.TextForDisplay : "エラー";
+                    if (s != null) {
+                        hiScoreRecord = new RankingRecord(_ncmbRecord.ObjectId,
+                                                          _ncmbRecord[COLUMN_NAME].ToString(),
+                                                          s,
+                                                          _ncmbRecord.ContainsKey(COLUMN_HASH) ? _ncmbRecord[COLUMN_HASH].ToString() : "");
+                        if (EnabledVerifyHash && !hiScoreRecord.VerifyHash()) {
+                            hiScoreRecord = null;
+                        }
+                    }
 
+                    highScoreLabel.text = hiScoreRecord != null ? hiScoreRecord.Score.TextForDisplay : "エラー";
                     nameInputField.text = _ncmbRecord[COLUMN_NAME].ToString();
                 }
                 else
@@ -111,26 +137,24 @@ namespace naichilab
             yield return StartCoroutine(LoadRankingBoard());
 
             //スコア更新している場合、ボタン有効化
-            if (_ncmbRecord == null)
+            if (hiScoreRecord == null)
             {
                 sendScoreButton.interactable = true;
             }
             else
             {
-                var highScore = _board.BuildScore(_ncmbRecord[COLUMN_SCORE].ToString());
-
                 if (_board.Order == ScoreOrder.OrderByAscending)
                 {
                     //数値が低い方が高スコア
-                    sendScoreButton.interactable = _lastScore.Value < highScore.Value;
+                    sendScoreButton.interactable = _lastScoreRecord.Score.Value < hiScoreRecord.Score.Value;
                 }
                 else
                 {
                     //数値が高い方が高スコア
-                    sendScoreButton.interactable = highScore.Value < _lastScore.Value;
+                    sendScoreButton.interactable = hiScoreRecord.Score.Value < _lastScoreRecord.Score.Value;
                 }
 
-                Debug.Log(string.Format("登録済みスコア:{0} 今回スコア:{1} ハイスコア更新:{2}", highScore.Value, _lastScore.Value,
+                Debug.Log(string.Format("登録済みスコア:{0} 今回スコア:{1} ハイスコア更新:{2}", hiScoreRecord.Score.Value, _lastScoreRecord.Score.Value,
                     sendScoreButton.interactable));
             }
         }
@@ -143,6 +167,11 @@ namespace naichilab
 
         private IEnumerator SendScoreEnumerator()
         {
+            if (EnabledVerifyHash && !_lastScoreRecord.VerifyHash()) { // メモリが書き換えられてないかのチェック
+                highScoreLabel.text = "検証エラー";
+                yield break; 
+            }
+
             sendScoreButton.interactable = false;
             highScoreLabel.text = "送信中...";
 
@@ -154,7 +183,9 @@ namespace naichilab
             }
 
             _ncmbRecord[COLUMN_NAME] = InputtedNameForSave;
-            _ncmbRecord[COLUMN_SCORE] = _lastScore.Value;
+            _ncmbRecord[COLUMN_SCORE] = _lastScoreRecord.Score.Value;
+            _lastScoreRecord.ChangeName(InputtedNameForSave); // 名前変更
+            _ncmbRecord[COLUMN_HASH] = _lastScoreRecord.Hash;
             NCMBException errorResult = null;
 
             yield return _ncmbRecord.YieldableSaveAsync(error => errorResult = error);
@@ -169,7 +200,7 @@ namespace naichilab
             //ObjectIDを保存して次に備える
             ObjectID = _ncmbRecord.ObjectId;
 
-            highScoreLabel.text = _lastScore.TextForDisplay;
+            highScoreLabel.text = _lastScoreRecord.Score.TextForDisplay;
 
             yield return StartCoroutine(LoadRankingBoard());
         }
@@ -193,7 +224,7 @@ namespace naichilab
             MaskOffOn();
 
             var so = new YieldableNcmbQuery<NCMBObject>(_board.ClassName);
-            so.Limit = 30;
+            so.Limit = EnabledVerifyHash ? MAX_READ_ROW : MAX_VIEW_ROW;
             if (_board.Order == ScoreOrder.OrderByAscending)
             {
                 so.OrderByAscending(COLUMN_SCORE);
@@ -217,6 +248,17 @@ namespace naichilab
                 int rank = 0;
                 foreach (var r in so.Result)
                 {
+                    if (rank >= MAX_VIEW_ROW) break;
+
+                    IScore highScore = _board.BuildScore(r[COLUMN_SCORE].ToString());
+                    if (highScore == null) continue;
+
+                    RankingRecord highScoreRecord = new RankingRecord(r.ObjectId,
+                                                                      r[COLUMN_NAME].ToString(),
+                                                                      highScore,
+                                                                      r.ContainsKey(COLUMN_HASH) ? r[COLUMN_HASH].ToString() : "");
+                    if (EnabledVerifyHash && !highScoreRecord.VerifyHash()) continue;
+
                     var n = Instantiate(rankingNodePrefab, scrollViewContent);
                     var rankNode = n.GetComponent<RankingNode>();
                     rankNode.NoText.text = (++rank).ToString();

--- a/Assets/naichilab/unity-simple-ranking/Scripts/StringExtensions.cs
+++ b/Assets/naichilab/unity-simple-ranking/Scripts/StringExtensions.cs
@@ -1,0 +1,47 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+using System.Security.Cryptography;
+using System.Text;
+
+namespace naichilab
+{
+    // <summary>
+    /// string型の拡張メソッド
+    /// </summary>
+    public static class StringExtensions
+    {
+        /// <summary>
+        /// 空チェック
+        /// </summary>
+        /// <returns></returns>
+        public static bool IsNullOrEmpty(this string self)
+        {
+            return string.IsNullOrEmpty(self);
+        }
+
+        /// <summary>
+        /// ハッシュ化（HMACSHA256）
+        /// 参考:http://hensa40.cutegirl.jp/archives/4066
+        ///      環境的に SHA256CryptoServiceProvider が存在しないので HMACSHA256 を使用
+        /// </summary>
+        /// <returns></returns>
+        public static string ToHMACSHA256(this string self)
+        {            
+            // パスワードをUTF-8エンコードでバイト配列として取り出す
+            byte[] byteValues = System.Text.Encoding.UTF8.GetBytes(self);
+
+            // HMACSHA256のハッシュ値を計算する
+            HMACSHA256 crypto256 = new HMACSHA256(byteValues);
+            byte[] hash256Value = crypto256.ComputeHash(byteValues);
+
+            // HMACSHA256の計算結果をUTF8で文字列として取り出す
+            StringBuilder hashedText = new StringBuilder();
+            for (int i = 0; i < hash256Value.Length; i++) {
+                // 16進の数値を文字列として取り出す
+                hashedText.AppendFormat("{0:X2}", hash256Value[i]);
+            }
+            return hashedText.ToString();
+        }
+    }
+}

--- a/Assets/naichilab/unity-simple-ranking/Scripts/StringExtensions.cs.meta
+++ b/Assets/naichilab/unity-simple-ranking/Scripts/StringExtensions.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 7e2093e4e1904f34c8f29020ed24f5ca
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
ハッシュ値による検証の仕組みを用意し、ハイスコアのメモリ改ざんと通信パケット改ざんの対策を行いました。
セキュリティに詳しい人間ではないので中途半端な対応ですが、良かったらマージしてください。

■使い方
検証を有効にするには、RankingLoader.cs の EnabledVerifyHash を true にしてください。

■挙動
ハイスコアの登録データからハッシュ値を計算するようにしています。
検証を有効にすると、ハッシュ値が一致しない登録データははじかれます。
この時、旧来のDBに登録済みのデータはハッシュ値が登録されていないので全てエラーではじかれます。
検証が無効でも、今後新しく登録されたデータにはハッシュ値が付与されて登録されます。
なお、ハッシュの計算にクライアントキーを使用しているため、クライアントキーを変更するとDBに登録済みのデータは全て無効として扱われます。

■制限事項
改ざんされたデータを表示時にはじくことはできるのですが、改ざんされた通信パケットのDBへの登録を遮断することができません。
そのため、改ざんされた無効なデータはDBに貯まっていくことになります。
無効なデータかどうかは取得しないと分からないため、現状は60行を読み込み、そのうち無効でない30行を表示する設定にしています。
無効なデータが多くなり、有効なデータが足りなくなると、結果として表示行が少なくなります。

■メモリ改ざんの対策と注意事項
RankingRecordクラス のメモリ改ざんについては対策していますが、SampleSceneManagerクラス のメモリ改ざんは対策していません。
ただWebアプリであればメモリ改ざんは難しいのではないかと思います。
（Webアプリは試してないので間違ってるかも。。。）
念のため SampleSceneManagerクラス にコメントを残しています。